### PR TITLE
Configurable data location

### DIFF
--- a/gaiadmpconf/conf.py
+++ b/gaiadmpconf/conf.py
@@ -1,0 +1,1 @@
+GAIA_DATA_LOCATION = 'file:///data/gaia'

--- a/gaiadmpconf/conf.py
+++ b/gaiadmpconf/conf.py
@@ -1,1 +1,1 @@
-GAIA_DATA_LOCATION = 'file:///data/gaia'
+GAIA_DATA_LOCATION = 'file:///data/gaia/'

--- a/gaiadmpsetup/gaiadmpsetup.py
+++ b/gaiadmpsetup/gaiadmpsetup.py
@@ -5,6 +5,25 @@ from pyspark.sql.utils import AnalysisException
 from . import gaiaedr3_pyspark_schema_structures as edr3
 from . import gaiadr3_pyspark_schema_structures as dr3
 from .gaiadmpstore import *
+from gaiadmpconf import conf
+
+from urllib.parse import urlsplit, unquote_plus
+from pathlib import Path
+
+spark = SparkSession.builder.getOrCreate()
+
+class Location(object):
+
+    def __init__(self, url):
+        (scheme, net_loc, path, _, _) = urlsplit(url)
+        path = Path(unquote_plus(path))
+        self.parts = (scheme, net_loc, path)
+
+    def __eq__(self, other):
+        return self.parts == other.parts
+
+    def __hash__(self):
+        return hash(self.parts)
 
 spark = SparkSession.builder.getOrCreate()
 
@@ -13,11 +32,18 @@ class GaiaDMPSetup:
     Prepare the PySpark env for GaiaDMP
     """
 
+    databases = {
+        'gaiaedr3': edr3,
+        'gaiadr3': dr3,
+    }
+
     def __init__(self):
         pass
 
     @staticmethod
     def setup():
+
+        data_store = conf.GAIA_DATA_LOCATION
 
         def tablesExist(expected_tables, database):
         
@@ -33,35 +59,30 @@ class GaiaDMPSetup:
                 
             return check
 
-        # check EDR3
-        database = "gaiaedr3"
-        if not tablesExist(edr3.table_dict.keys(), database):
-        
-            # create the database and switch the current SQL database context to it (from default)
-            spark.sql("create database if not exists " + database)
-            spark.sql("use " + database)
+        def location_changed(expected_location, database):
+            check = False
+            for table_key in schema.table_dict.keys():
+                location = spark.sql(f"desc formatted {table_key}").filter("col_name=='Location'").collect()[0].data_type
+                folder_path = schema.table_dict[table_key][1]
+                if Location(location) != Location(expected_location + folder_path):
+                    check = True
+                # only compare the first table, assuming they are all the same
+                break
+            return check
 
-            # create the tables against their corresponding file sets and schema
-            for table_key in edr3.table_dict.keys():
-                folder_path = edr3.table_dict[table_key][1]
-                schemas = edr3.table_dict[table_key][0]
-                pk = edr3.table_dict[table_key][2]
-                reattachParquetFileResourceToSparkContext(table_key, data_store + folder_path, schemas, cluster_key = pk, sort_key = pk)
-                
-        # check DR3
-        database = "gaiadr3"
-        if not tablesExist(dr3.table_dict.keys(), database):
-        
-            # ... similarly for Gaia DR3
-            spark.sql("create database if not exists " + database)
-            spark.sql("use " + database)
+        for database, schema in GaiaDMPSetup.databases.items():
+            if not tablesExist(schema.table_dict.keys(), database) or location_changed(data_store, database):
 
-            # create the tables against their corresponding file sets and schema            
-            for table_key in dr3.table_dict.keys():
-                folder_path = dr3.table_dict[table_key][1]
-                schemas = dr3.table_dict[table_key][0]
-                pk = dr3.table_dict[table_key][2]
-                reattachParquetFileResourceToSparkContext(table_key, data_store + folder_path, schemas, cluster_key = pk, sort_key = pk)
+                # create the database and switch the current SQL database context to it (from default)
+                spark.sql("create database if not exists " + database)
+                spark.sql("use " + database)
+
+                # create the tables against their corresponding file sets and schema
+                for table_key in schema.table_dict.keys():
+                    folder_path = schema.table_dict[table_key][1]
+                    schemas = schema.table_dict[table_key][0]
+                    pk = schema.table_dict[table_key][2]
+                    reattachParquetFileResourceToSparkContext(table_key, data_store + folder_path, schemas, cluster_key = pk, sort_key = pk)
         
         # finally always leave the PySpark SQL context in the most recent Gaia DR3 database
         spark.sql("use gaiadr3")

--- a/gaiadmpsetup/gaiadmpsetup.py
+++ b/gaiadmpsetup/gaiadmpsetup.py
@@ -59,7 +59,7 @@ class GaiaDMPSetup:
                 
             return check
 
-        def location_changed(expected_location, database):
+        def location_changed(expected_location, schema):
             check = False
             for table_key in schema.table_dict.keys():
                 location = spark.sql(f"desc formatted {table_key}").filter("col_name=='Location'").collect()[0].data_type
@@ -71,7 +71,7 @@ class GaiaDMPSetup:
             return check
 
         for database, schema in GaiaDMPSetup.databases.items():
-            if not tablesExist(schema.table_dict.keys(), database) or location_changed(data_store, database):
+            if not tablesExist(schema.table_dict.keys(), database) or location_changed(data_store, schema):
 
                 # create the database and switch the current SQL database context to it (from default)
                 spark.sql("create database if not exists " + database)

--- a/gaiadmpsetup/gaiadmpstore.py
+++ b/gaiadmpsetup/gaiadmpstore.py
@@ -9,9 +9,6 @@ NUM_BUCKETS = 2048
 
 spark = SparkSession.builder.getOrCreate()
 
-# root data store path: TODO change this to the official one when established.
-data_store = os.getenv('GAIA_DMP_STORE', "file:////data/gaia/")
-
 # default key by which to bucket and sort: Gaia catalogue source UID 
 default_key = "source_id"
 

--- a/gaiadmpsetup/gaiadmpstore.py
+++ b/gaiadmpsetup/gaiadmpstore.py
@@ -2,7 +2,6 @@ from pyspark.sql.types import *
 from pyspark.sql import functions as f
 from pyspark.sql import *
 
-import os
 
 # number of buckets for our platform
 NUM_BUCKETS = 2048

--- a/gaiadmpsetup/gaiadmpstore.py
+++ b/gaiadmpsetup/gaiadmpstore.py
@@ -2,6 +2,7 @@ from pyspark.sql.types import *
 from pyspark.sql import functions as f
 from pyspark.sql import *
 
+import os
 
 # number of buckets for our platform
 NUM_BUCKETS = 2048
@@ -9,7 +10,7 @@ NUM_BUCKETS = 2048
 spark = SparkSession.builder.getOrCreate()
 
 # root data store path: TODO change this to the official one when established.
-data_store = "file:////data/gaia/"  # "file:////user/nch/PARQUET/REPARTITIONED/"
+data_store = os.getenv('GAIA_DMP_STORE', "file:////data/gaia/")
 
 # default key by which to bucket and sort: Gaia catalogue source UID 
 default_key = "source_id"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name = "gaiadmpsetup",
-    version = "0.1.1",
+    version = "0.1.2",
     author = "Stelios Voutsinas",
     author_email = "stv@roe.ac.uk",
     description = ("A setup script for Gaia DMP"),

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     keywords = "gaiadmpsetup",
     url = "https://github.com/wfau/aglais",
     include_package_data = True,
-    packages=['gaiadmpsetup'],
+    packages=['gaiadmpsetup', 'gaiadmpconf'],
     long_description="README",
     long_description_content_type='text/markdown',
     classifiers=[


### PR DESCRIPTION
Proposed solution for wfau/gaia-dmp#1053 (Configurable data location).

There is a new `conf` module that configures the `GAIA_DATA_LOCATION`, for example:
```
from gaiadmpconf import conf
conf.GAIA_DATA_LOCATION = 'hdfs:///data/gaia/'

# now run the setup
import gaiadmpsetup
```

The default location is `file:///data/gaia`, so the module can be imported as before:
```
import gaiadmpsetup
```

If the tables exist but the location has changed, the tables are dropped and re-attached when setup is called.
